### PR TITLE
Email should open as links

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@ xmlns:fb="http://www.facebook.com/2008/fbml"><!--formatted-->
                 <br><br><hr>
                 <br><br><br>
                 <h3 class="center">Want to become a sponsor?<br>
-                Send us an email at hackathon@cougarcs.com</h4>
+                Send us an email at <a href="mailto:hackathon@cougarcs.com">hackathon@cougarcs.com</a></h4>
             </div>
         </section>
 
@@ -324,7 +324,7 @@ xmlns:fb="http://www.facebook.com/2008/fbml"><!--formatted-->
               <h5>&copy; 2014-2015 CougarCS.</h5>
           </div>
           <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="footerRight">
-              <h5>Contact us at hackathon@cougarcs.com</h5>
+              <h5>Contact us at <a href="mailto:hackathon@cougarcs.com">hackathon@cougarcs.com</a></h5>
           </div>
         </div>
         </div>


### PR DESCRIPTION
It makes more hassle to copy and paste the email address. So, I put them as links for simplicity.

This is the cleaned up version of #5.